### PR TITLE
Set pushType to natural after backTrack has fired

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -84,9 +84,9 @@ const callLater = require('callLater');
 log('data =', data);
 
 //Check if backTrack has already fired/is firing by looking for artificial/natural pushType
-let pushType = copyFromDataLayer('pushType');
+let alreadyFired = copyFromDataLayer('backTrack_fired');
 
-if (['artificial', 'natural'].indexOf(pushType) === -1) {
+if (!alreadyFired) {
 
     //Copy the dataLayer and filter out pushes without the event key
     let dataLayer = copyFromWindow('dataLayer').filter(key => key && key.event);
@@ -132,12 +132,15 @@ if (['artificial', 'natural'].indexOf(pushType) === -1) {
             log('Repeat DataLayer Events Tag - Repushing event: ' + element.event);
             //Repush the event
             callLater(()=>dataLayerPush(element));
-            callLater(()=>dataLayerPush({pushType: 'natural'}));
         });
+            callLater(()=>dataLayerPush({
+              backTrack_fired : true,
+              pushType: undefined}));
+        
 
     }
 } else {
-  log('backTrack aborted - artificial events already detected');
+  log('backTrack aborted - tag has already fired');
 }
 // Call data.gtmOnSuccess when the tag is finished.
 data.gtmOnSuccess();
@@ -275,6 +278,13 @@ ___WEB_PERMISSIONS___
       },
       "param": [
         {
+          "key": "allowedKeys",
+          "value": {
+            "type": 1,
+            "string": "specific"
+          }
+        },
+        {
           "key": "keyPatterns",
           "value": {
             "type": 2,
@@ -286,6 +296,10 @@ ___WEB_PERMISSIONS___
               {
                 "type": 1,
                 "string": "pushType"
+              },
+              {
+                "type": 1,
+                "string": "backTrack_fired"
               }
             ]
           }
@@ -393,5 +407,3 @@ setup: "const log = require('logToConsole');\n\nconst mockData = {\n  positive_r
 ___NOTES___
 
 Set firing to once per page
-
-

--- a/template.tpl
+++ b/template.tpl
@@ -83,10 +83,10 @@ const callLater = require('callLater');
 
 log('data =', data);
 
-//Check for any artifical dataLayer events and abort if any are detected, as this means the tag has already fired
+//Check if backTrack has already fired/is firing by looking for artificial/natural pushType
 let pushType = copyFromDataLayer('pushType');
 
-if (pushType !== 'artificial') {
+if (['artificial', 'natural'].indexOf(pushType) === -1) {
 
     //Copy the dataLayer and filter out pushes without the event key
     let dataLayer = copyFromWindow('dataLayer').filter(key => key && key.event);
@@ -132,6 +132,7 @@ if (pushType !== 'artificial') {
             log('Repeat DataLayer Events Tag - Repushing event: ' + element.event);
             //Repush the event
             callLater(()=>dataLayerPush(element));
+            callLater(()=>dataLayerPush({pushType: 'natural'}));
         });
 
     }


### PR DESCRIPTION
Due to dataLayer persistency, the value of 'pushType' will currently remain as 'artificial' for events fired after backTrack.
By changing the value to 'natural' after the tag has finished re-pushing events - we can allow 'artificial' and 'natural' events to be distinguished.
The safety nets have been updated to abort firing of the logic when either 'natural' or 'artificial' are detected as the value for 'pushType'.